### PR TITLE
Disable voice introductions for now...

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ A simple dice roller. Here are some examples:
 
 ### 📯 Introductions
 
+NOTE: _This functionality is currently disabled. YouTube is not happy with my usage
+of yt-dlp..._ 👀
+
 Plays a user's introduction sound when they join a voice channel. This is configurable with the following commands:
 
 - `/set_intro` - Add an introduction sound from a YouTube URL

--- a/src/app_builder.rs
+++ b/src/app_builder.rs
@@ -30,9 +30,9 @@ pub async fn build(discord_token: String, pool: sqlx::PgPool) -> Client {
                 introductions::commands::clear_intro(),
                 rolls::commands::roll(),
             ],
-            event_handler: |ctx, event, framework, data| {
-                Box::pin(handlers::event_handler(ctx, event, framework, data))
-            },
+            // event_handler: |ctx, event, framework, data| {
+            //     Box::pin(handlers::event_handler(ctx, event, framework, data))
+            // },
             on_error: |error| Box::pin(handlers::on_error(error)),
             ..Default::default()
         })

--- a/src/introductions/commands.rs
+++ b/src/introductions/commands.rs
@@ -28,6 +28,8 @@ async fn get_yt_track_duration(
     }
 }
 
+const VOICE_DISABLED_MSG: &str = "Voice introductions have been temporarily disabled. YouTube is blocking my IP because it thinks I'm a bot 👀";
+
 /// Set your intro sound from a YouTube URL.
 ///
 /// This sound plays when you join a voice channel. The sound is streamed
@@ -38,41 +40,43 @@ pub async fn set_intro(
     ctx: Context<'_>,
     #[description = "YouTube URL (video must be less than 5s long)"] url: String,
 ) -> Result<(), Error> {
-    const MAX_INTRO_DURATION: Duration = Duration::from_secs(5);
+    // const MAX_INTRO_DURATION: Duration = Duration::from_secs(5);
+    //
+    // let user_id = ctx.author().id;
+    // let guild_id = match ctx.guild_id() {
+    //     Some(guild_id) => guild_id,
+    //     None => {
+    //         err_say(&ctx, "This command can only be used in a server.").await?;
+    //         return Ok(());
+    //     }
+    // };
+    // if !youtube_url_is_valid(url.as_str())? {
+    //     err_say(&ctx, "Invalid YouTube URL.").await?;
+    //     return Ok(());
+    // }
+    //
+    // if let Some(duration) =
+    //     get_yt_track_duration(ctx.data().http_client.clone(), url.as_str()).await
+    // {
+    //     if duration > MAX_INTRO_DURATION {
+    //         err_say(&ctx, "The video must be less than 5 seconds long.").await?;
+    //         return Ok(());
+    //     }
+    // } else {
+    //     return Err("Failed to get video duration.".into());
+    // }
+    //
+    // set_url_for_user_and_guild(
+    //     user_id.get(),
+    //     guild_id.get(),
+    //     url.as_str(),
+    //     ctx.data().database.clone(),
+    // )
+    // .await?;
+    //
+    // ctx.say("📯 Your intro sound has been set!").await?;
 
-    let user_id = ctx.author().id;
-    let guild_id = match ctx.guild_id() {
-        Some(guild_id) => guild_id,
-        None => {
-            err_say(&ctx, "This command can only be used in a server.").await?;
-            return Ok(());
-        }
-    };
-    if !youtube_url_is_valid(url.as_str())? {
-        err_say(&ctx, "Invalid YouTube URL.").await?;
-        return Ok(());
-    }
-
-    if let Some(duration) =
-        get_yt_track_duration(ctx.data().http_client.clone(), url.as_str()).await
-    {
-        if duration > MAX_INTRO_DURATION {
-            err_say(&ctx, "The video must be less than 5 seconds long.").await?;
-            return Ok(());
-        }
-    } else {
-        return Err("Failed to get video duration.".into());
-    }
-
-    set_url_for_user_and_guild(
-        user_id.get(),
-        guild_id.get(),
-        url.as_str(),
-        ctx.data().database.clone(),
-    )
-    .await?;
-
-    ctx.say("📯 Your intro sound has been set!").await?;
+    ctx.say(VOICE_DISABLED_MSG).await?;
 
     Ok(())
 }
@@ -83,22 +87,24 @@ pub async fn set_intro(
 /// channel. To set a new intro sound, use the `/set_intro` command.
 #[poise::command(slash_command)]
 pub async fn clear_intro(ctx: Context<'_>) -> Result<(), Error> {
-    let guild_id = match ctx.guild_id() {
-        Some(guild_id) => guild_id,
-        None => {
-            err_say(&ctx, "This command can only be used in a server.").await?;
-            return Ok(());
-        }
-    };
+    // let guild_id = match ctx.guild_id() {
+    //     Some(guild_id) => guild_id,
+    //     None => {
+    //         err_say(&ctx, "This command can only be used in a server.").await?;
+    //         return Ok(());
+    //     }
+    // };
+    //
+    // clear_url_for_user_and_guild(
+    //     ctx.author().id.get(),
+    //     guild_id.get(),
+    //     ctx.data().database.clone(),
+    // )
+    // .await?;
+    //
+    // ctx.say("🧹 Your intro sound has been cleared!").await?;
 
-    clear_url_for_user_and_guild(
-        ctx.author().id.get(),
-        guild_id.get(),
-        ctx.data().database.clone(),
-    )
-    .await?;
-
-    ctx.say("🧹 Your intro sound has been cleared!").await?;
+    ctx.say(VOICE_DISABLED_MSG).await?;
 
     Ok(())
 }


### PR DESCRIPTION
See https://github.com/yt-dlp/yt-dlp/issues/10128. When I get a chance I'll try fix this using OAuth2 or cookies and then use `yt-dlp` only for the initial download (and store elsewhere) so that the IP doesn't get blocked again.