### PR TITLE
Autobahn test cases 1.1.1 - 1.1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ zig-out
 
 # macOS
 .DS_Store
-reports
+
+# wstest results
+autobahn-testsuite/reports

--- a/autobahn-testsuite/fuzzingserver.json
+++ b/autobahn-testsuite/fuzzingserver.json
@@ -1,7 +1,7 @@
 {
   "url": "ws://127.0.0.1:9001",
   "outdir": "/mount/reports",
-  "cases": ["1.1.1", "1.1.2", "1.1.3"],
+  "cases": ["1.1.1", "1.1.2", "1.1.3", "1.1.4", "1.1.5"],
   "exclude-cases": [],
   "exclude-agent-cases": {}
 }

--- a/autobahn-testsuite/fuzzingserver.json
+++ b/autobahn-testsuite/fuzzingserver.json
@@ -1,7 +1,7 @@
 {
   "url": "ws://127.0.0.1:9001",
   "outdir": "/mount/reports",
-  "cases": ["1.1.1"],
+  "cases": ["1.1.1", "1.1.2", "1.1.3"],
   "exclude-cases": [],
   "exclude-agent-cases": {}
 }

--- a/autobahn-testsuite/fuzzingserver.json
+++ b/autobahn-testsuite/fuzzingserver.json
@@ -1,6 +1,6 @@
 {
   "url": "ws://127.0.0.1:9001",
-  "outdir": "./reports/clients",
+  "outdir": "/mount/reports",
   "cases": ["1.1.1"],
   "exclude-cases": [],
   "exclude-agent-cases": {}

--- a/src/websocket_client.zig
+++ b/src/websocket_client.zig
@@ -226,6 +226,12 @@ test "autobahn" {
         std.debug.print("Case count: {s}\n", .{r});
         const case_count = try std.fmt.parseInt(u16, r, 10);
 
+        defer _ = websocket(
+            allocator,
+            &buffer,
+            "/updateReports?agent=Adventus",
+        ) catch @panic("Failed to generate wstest report\n");
+
         for (1..case_count + 1) |case| {
             std.debug.print("\nCASE {d}\n\n", .{case});
 
@@ -238,8 +244,6 @@ test "autobahn" {
 
             _ = try websocket(allocator, &buffer, path);
         }
-
-        _ = try websocket(allocator, &buffer, "/updateReports?agent=Adventus");
     }
 
     // TODO: CHECK RESULTS BY COMPARING TO EXPECTED INDEX.JSON

--- a/src/websocket_client.zig
+++ b/src/websocket_client.zig
@@ -131,10 +131,8 @@ fn websocket(allocator: std.mem.Allocator, buffer: []u8, path: []const u8) !?[]u
                 write_buffer[1] = 0x80 | @as(u8, @truncate(payload.len));
                 write_buffer[2..6].* = mask_key;
 
-                var j: usize = 0;
                 for (payload, 6..) |byte, i| {
-                    write_buffer[i] = byte ^ mask_key[j % 4];
-                    j += 1;
+                    write_buffer[i] = byte ^ mask_key[(i - 6) % 4]; // re-use i for mask, must start at 0
                 }
 
                 _ = try std.posix.write(socket, write_buffer[0 .. 6 + payload.len]);

--- a/src/websocket_client.zig
+++ b/src/websocket_client.zig
@@ -95,21 +95,28 @@ fn websocket(allocator: std.mem.Allocator, buffer: []u8, path: []const u8) !?[]u
         // second byte: mask bit and payload size
         try std.testing.expect(frame_header[1] & 0b10000000 == 0); // server messages not masked
 
-        // TODO: use a cool 'blk:' return here
-        // TODO: try a cool range switch statement here
-        const payload_len: u8 = frame_header[1] & 0b01111111; // response payload length same as payload sent
-        try std.testing.expect(payload_len <= 125); // TODO: handle larger payload sizes
-
-        // // check if we need to read further for payload length
-        // if (payload_len == 126) {
-        //     try std.testing.expect(pos + 2 > bytes_read); // TODO: handle not enough bytes
-        //     // TODO: read payload size
-        // } else if (payload_len == 127) {
-        //     try std.testing.expect(pos + 8 > bytes_read); // TODO: handle not enough bytes
-        //     // TODO: read payload size
-        // }
-
-        if (pos + payload_len > bytes_read) continue;
+        const short_payload_len: u8 = frame_header[1] & 0b01111111;
+        // FIXME: handle not having enough bytes
+        const payload_len = switch (short_payload_len) { // keep in mind network byte ordering (big endian)
+            0...125 => short_payload_len,
+            126 => blk: {
+                const payload_len = std.mem.bigToNative(
+                    u16,
+                    std.mem.bytesToValue(u16, buffer[pos .. pos + 2]),
+                );
+                pos += 2;
+                break :blk payload_len;
+            },
+            127 => blk: {
+                const payload_len = std.mem.bigToNative(
+                    u64,
+                    std.mem.bytesToValue(u64, buffer[pos .. pos + 8]),
+                );
+                pos += 8;
+                break :blk payload_len;
+            },
+            else => unreachable,
+        };
 
         // remaining bytes are the payload (messages from server are unmasked, so the key is omitted)
         const payload = buffer[pos .. pos + payload_len];
@@ -121,21 +128,51 @@ fn websocket(allocator: std.mem.Allocator, buffer: []u8, path: []const u8) !?[]u
 
         switch (opcode) {
             0x1 => {
+                // wstest expects echo
                 std.debug.print("Received text: {s}\n", .{payload});
 
-                // wstest expects echo
                 const mask_key = maskKey();
 
-                write_buffer[0] = 0x81; // fin == 1, opcode == 1 (text)
-                // FIXME: check send size
-                write_buffer[1] = 0x80 | @as(u8, @truncate(payload.len));
-                write_buffer[2..6].* = mask_key;
+                const short_len: u8 = switch (payload.len) {
+                    0...125 => @intCast(payload.len), // direct payload length in 7 bits
+                    126...std.math.maxInt(u16) => 126, // use 16-bit extended length
+                    (std.math.maxInt(u16) + 1)...std.math.maxInt(u64) => 127, // use 64-bit extended length
+                };
 
-                for (payload, 6..) |byte, i| {
-                    write_buffer[i] = byte ^ mask_key[(i - 6) % 4]; // re-use i for mask, must start at 0
+                write_buffer[0] = 0x81; // fin == 1, opcode == 1 (text)
+                write_buffer[1] = 0x80 | @as(u8, short_len);
+
+                var write_pos: usize = 2;
+
+                // append extended payload length if necessary
+                if (short_len == 126) {
+                    std.mem.writeInt(
+                        u16,
+                        write_buffer[write_pos..][0..2],
+                        @as(u16, @intCast(payload.len)),
+                        .big,
+                    );
+                    write_pos += 2;
+                } else if (short_len == 127) {
+                    std.mem.writeInt(
+                        u64,
+                        write_buffer[write_pos..][0..8],
+                        @as(u64, @intCast(payload.len)),
+                        .big,
+                    );
+                    write_pos += 8;
                 }
 
-                _ = try std.posix.write(socket, write_buffer[0 .. 6 + payload.len]);
+                std.mem.copyForwards(u8, write_buffer[write_pos .. write_pos + 4], &mask_key);
+                write_pos += 4;
+
+                for (payload, 0..) |byte, i| {
+                    write_buffer[write_pos + i] = byte ^ mask_key[i % 4];
+                }
+
+                std.debug.print("Sending echo\n", .{});
+
+                _ = try std.posix.write(socket, write_buffer[0 .. write_pos + payload.len]);
             },
             0x8 => {
                 std.debug.print("Received close frame\n", .{});

--- a/wstest.sh
+++ b/wstest.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-docker run --rm --interactive --tty \
-  -v "$PWD/config:/config" \
-  -v "$PWD/reports:/reports" \
-  -p 9001:9001 \
-  --name fuzzingserver \
-  crossbario/autobahn-testsuite wstest --debug --mode=fuzzingserver --spec=/config/fuzzingserver.json


### PR DESCRIPTION
- start and stop container from test in Zig
- enable the test cases in the configuration
- 1.1.1 - 1.1.2: just had to get it to echo messages
- 1.1.3 - 1.1.5: requires handling extended payload size when reading and writing frames
