### PR TITLE
Autobahn tests: Get all text test cases (1.1.*) passing!

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,19 @@
+# Notes
+
+## Optimisations to try
+
+### Write to socket stream in chunks to use less memory?
+
+```zig
+// Write masked payload in chunks
+var chunk: [4096]u8 = undefined;
+var offset: usize = 0;
+while (offset < payload.len) {
+    const chunk_size = @min(chunk.len, payload.len - offset);
+    for (0..chunk_size) |i| {
+        chunk[i] = payload[offset + i] ^ mask_key[(offset + i) % 4];
+    }
+    try writer.writeAll(chunk[0..chunk_size]);
+    offset += chunk_size;
+}
+```

--- a/autobahn-testsuite/fuzzingserver.json
+++ b/autobahn-testsuite/fuzzingserver.json
@@ -1,7 +1,7 @@
 {
   "url": "ws://127.0.0.1:9001",
   "outdir": "/mount/reports",
-  "cases": ["1.1.1", "1.1.2", "1.1.3", "1.1.4", "1.1.5"],
+  "cases": ["1.1.*"],
   "exclude-cases": [],
   "exclude-agent-cases": {}
 }

--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,20 @@ pub fn build(b: *std.Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
+    const lib = b.addStaticLibrary(.{
+        .name = "zig-test",
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
+        .root_source_file = b.path("src/websocket_client.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // This declares intent for the library to be installed into the standard
+    // location when the user invokes the "install" step (the default step when
+    // running `zig build`).
+    b.installArtifact(lib);
+
     const exe = b.addExecutable(.{
         .name = "adventus",
         .root_source_file = b.path("src/main.zig"),
@@ -52,6 +66,16 @@ pub fn build(b: *std.Build) void {
 
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.
+
+    const lib_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/websocket_client.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+    run_lib_unit_tests.has_side_effects = true; // so that test runs aren't cached
+
     const exe_unit_tests = b.addTest(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
@@ -65,5 +89,6 @@ pub fn build(b: *std.Build) void {
     // the `zig build --help` menu, providing a way for the user to request
     // running the unit tests.
     const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_exe_unit_tests.step);
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729980323,
-        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
+        "lastModified": 1741708242,
+        "narHash": "sha256-cNRqdQD4sZpN7JLqxVOze4+WsWTmv2DGH0wNCOVwrWc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
+        "rev": "b62d2a95c72fb068aecd374a7262b37ed92df82b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Main changes here are how we manage socket reads and writes and memory management. 

Instead of manually managing read and write buffers we're now using `std.net.Stream` to connect the socket. It provides a`Reader` and `Writer` abstractions that allow for reading/writing only the bytes you want, no need to buffer. Here's an example:

```zig
// before
const frame_header = buffer[pos .. pos + 2];
pos += 2;
// after
const frame_header = try reader.readBytesNoEof(2);
```

Since we've done away with the buffers we're allocating on the heap for the payload when receiving and sending frames.