### PR TITLE
Move control flow from client to app

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
         .name = "zig-test",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
-        .root_source_file = b.path("src/websocket_client.zig"),
+        .root_source_file = b.path("src/websocket.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -68,7 +68,7 @@ pub fn build(b: *std.Build) void {
     // but does not run it.
 
     const lib_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/websocket_client.zig"),
+        .root_source_file = b.path("src/websocket.zig"),
         .target = target,
         .optimize = optimize,
     });


### PR DESCRIPTION
This significantly refactors the WebSocket client: the logic is split into the API methods `Connect`, `read`, and `writeMessage` of the new `Client` struct. `Connect` connects the socket and sends the upgrade returning a `Client` struct (thus the capitalisation). `read` reads frames until a `Message` (new struct encapsulating received application data: text/binary messages) is available then yields it to the caller OR returns `null` if the client or server have dropped the connection. `writeMessage` is an abstraction over `writeFrame` which does what it says.

This means we no longer have to worry about passing a handler callback (which was getting messy). The application can now use some fancy `while` syntax for handling the WebSocket messages. Here's how we run the test cases of the Autobahn testsuite which require the client echos all messages.

```zig
const client = try Client.Connect(allocator, path);
while (try client.read(buffer)) |message| { // loop until connection drops
    client.writeMessage(message); // wstest (autobahn) expects echo
}
client.deinit();
```